### PR TITLE
Fix Bluesky media upload by passing plain blob objects

### DIFF
--- a/src/sync/platforms/bluesky/index.ts
+++ b/src/sync/platforms/bluesky/index.ts
@@ -52,7 +52,7 @@ export async function getExternalEmbedding(
         uri: card.url,
         title: card.title,
         description: card.description,
-        thumb: card.image?.data.blob,
+        thumb: card.image,
         $type: "app.bsky.embed.external#external",
       },
     };
@@ -264,7 +264,7 @@ export const BlueskySynchronizerFactory: SynchronizerFactory<
                 photo.file,
                 agent,
               );
-              if (!res) {
+              if (!res || !blobRef) {
                 throw new Error(
                   "Failed to upload photo to bluesky: upload result is undefined",
                 );

--- a/src/sync/platforms/bluesky/utils/get-bluesky-link-metadata.ts
+++ b/src/sync/platforms/bluesky/utils/get-bluesky-link-metadata.ts
@@ -5,7 +5,7 @@ import { uploadBlueskyMedia } from "./upload-bluesky-media";
 // import { parseBlobForBluesky } from "./parse-blob-for-bluesky";
 
 export type BlueskyLinkMetadata = Omit<LinkMetadata, "image"> & {
-  image: ComAtprotoRepoUploadBlob.Response | undefined;
+  image: ComAtprotoRepoUploadBlob.OutputSchema["blob"] | undefined;
 };
 
 /**
@@ -44,10 +44,10 @@ export async function getBlueskyLinkMetadata(
   // const media = await client.uploadBlob(blueskyBlob.data, {
   //   encoding: blueskyBlob.mimeType,
   // });
-  const media = await uploadBlueskyMedia(mediaBlob, client);
+  const { blobRef } = await uploadBlueskyMedia(mediaBlob, client);
 
   return {
     ...data,
-    image: media,
+    image: blobRef,
   };
 }

--- a/src/sync/platforms/bluesky/utils/upload-bluesky-media.ts
+++ b/src/sync/platforms/bluesky/utils/upload-bluesky-media.ts
@@ -34,7 +34,7 @@ export async function uploadBlueskyMedia(
     return { res };
   }
 
-  const blobRef = BlobRef.asBlobRef(res.data.blob.original) ?? undefined;
+  const blobRef = (res.data.blob as any).original ?? res.data.blob;
   debug("Uploaded media to Bluesky", { blobRef });
   return { res, blobRef };
 }


### PR DESCRIPTION
Fixes an issue where syncing media (profile pictures, banners, and video posts) to Bluesky fails with an `Invalid app.bsky.actor.profile record: Expected blob value type` error. The error is caused by passing `BlobRef` class instances instead of plain JSON objects to the strict lexicon validator in newer `@atproto/api` versions.

---
*PR created automatically by Jules for task [1074937707318475887](https://jules.google.com/task/1074937707318475887) started by @yamada-sexta*